### PR TITLE
Fix issue with hit distance calculation for constant medium

### DIFF
--- a/src/shapes/constant_medium.rs
+++ b/src/shapes/constant_medium.rs
@@ -72,7 +72,7 @@ impl Hittable for ConstantMedium {
         let distance_inside_boundary =
             (rec2.t - rec1.t) * ray_length;
         let hit_distance =
-            self.neg_inv_density * rng.gen::<f64>().log10();
+            self.neg_inv_density * rng.gen::<f64>().ln();
 
         if hit_distance > distance_inside_boundary {
             return None;


### PR DESCRIPTION
In the c++ code of the Ray Tracing in One Weekend series, it looks like they are using base 10 log. But apparently the log() function in c++ actually use the constant e as the base. Thus you should use ln() to calculate the hit_distance correctly.